### PR TITLE
Support showing all keyboards when the filtered text is empty.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,12 +38,12 @@ function App() {
         .then((kb) => {
           setKeyboardList(kb);
 
-          if (filterText !== "") {
-            const filteredList = kb.filter((kb: string) =>
-              kb.includes(filterText)
-            );
-            setKeyboardListFiltered(filteredList);
+          const filteredList = kb.filter((kb: string) => 
+            kb.includes(filterText)
+          );
+          setKeyboardListFiltered(filteredList);
 
+          if (filterText !== "") {
             if (filteredList.length > 0 && filteredList[0] != selectedKb) {
               setSelectedKb(filteredList[0]);
             }


### PR DESCRIPTION
This commit shows all keyboard list items when the filtered text is empty.

In the current situation, If the user clicks "選択してください" without any filtered text, the user cannot see any keyboard items.

Screenshot without this commit
![image](https://github.com/sekigon-gonnoc/bmp-vial-config-generator/assets/11634377/f2dae0cb-2f39-4f25-afc1-7498befee422)

Screenshot with this commit
![image](https://github.com/sekigon-gonnoc/bmp-vial-config-generator/assets/11634377/1701fdde-4e97-49f4-ab38-3cf1500ddd12)
